### PR TITLE
Bug 2348 - Only allow take picture when previewing

### DIFF
--- a/src/org/witness/informacam/ui/SurfaceGrabberActivity.java
+++ b/src/org/witness/informacam/ui/SurfaceGrabberActivity.java
@@ -43,6 +43,7 @@ public class SurfaceGrabberActivity extends Activity implements OnClickListener,
 	
 	private InformaCam informaCam = InformaCam.getInstance();
 	private List<String> baseImages = new ArrayList<String>();
+	private boolean mPreviewing;
 
 	private final static String LOG = App.ImageCapture.LOG;
 
@@ -87,6 +88,7 @@ public class SurfaceGrabberActivity extends Activity implements OnClickListener,
 	@Override
 	public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
 		camera.startPreview();
+		mPreviewing = true;
 	}
 
 	@Override
@@ -126,7 +128,8 @@ public class SurfaceGrabberActivity extends Activity implements OnClickListener,
 
 	@Override
 	public void onClick(View view) {
-		if(view == button) {
+		if(view == button && mPreviewing) {
+			mPreviewing = false;
 			camera.takePicture(null, null, this);
 		}
 	}
@@ -166,7 +169,13 @@ public class SurfaceGrabberActivity extends Activity implements OnClickListener,
 				}
 			}
 			
-			camera.startPreview();
+			view.post(new Runnable()
+			{
+				@Override
+				public void run() {
+					resumePreview();
+				}
+			});
 		}
 		catch (IOException ioe)
 		{
@@ -174,6 +183,12 @@ public class SurfaceGrabberActivity extends Activity implements OnClickListener,
 		}
 	}
 
+	private void resumePreview()
+	{
+		camera.startPreview();
+		mPreviewing = true;
+	}
+	
 	public void setCameraDisplayOrientation() 
 	{        
 	     if (camera == null)


### PR DESCRIPTION
Clicking in rapid succession on the "take picture" button would result in crash, since camera was not in preview mode.
