### PR TITLE
fix #2389 adds new Google Camera allowed camera apps

### DIFF
--- a/src/org/witness/informacam/utils/Constants.java
+++ b/src/org/witness/informacam/utils/Constants.java
@@ -663,6 +663,7 @@ public class Constants {
 				supported.add("com.sec.android.app.camera");
 				supported.add("com.android.camera");
 				supported.add("com.google.android.gallery3d");
+				supported.add("com.google.android.GoogleCamera");
 				SUPPORTED = Collections.unmodifiableList(supported);
 			}
 		}


### PR DESCRIPTION
support the new KitKat camera
