### PR TITLE
remove audio from md5 video calc for now

### DIFF
--- a/src/org/witness/informacam/informa/embed/VideoConstructor.java
+++ b/src/org/witness/informacam/informa/embed/VideoConstructor.java
@@ -95,7 +95,7 @@ public class VideoConstructor {
 				"-attach", fileMetadata.getAbsolutePath(),
 				"-metadata:s:2", "mimetype=text/plain",
 				"-vcodec", "copy",
-				"-acodec", "copy",
+				"-an",
 				fileOutput.getAbsolutePath()
 		};
 
@@ -161,7 +161,7 @@ public class VideoConstructor {
 			
 			String[] cmdHash = new String[] {
 					ffmpegBin, "-i", tmpMedia.getCanonicalPath(),
-					"-acodec", "copy", "-f", "md5", "-"
+					"-vcodec", "copy", "-acodec", "copy", "-f", "md5", "-"
 			};				
 			
 			if (extension.equalsIgnoreCase("jpg"))


### PR DESCRIPTION
md5 matching for video between source mp4 and output mkv does not work if you add audio in. 
